### PR TITLE
hr_payroll_account : allow to use employees' individual accounts

### DIFF
--- a/addons/hr_payroll_account/hr_payroll_account.py
+++ b/addons/hr_payroll_account/hr_payroll_account.py
@@ -125,8 +125,10 @@ class hr_payslip(osv.osv):
                         and slip.employee_id.address_home_id.property_account_payable):
                     debit_account_id = slip.employee_id.address_home_id.property_account_payable.id
                     partner_id = slip.employee_id.address_home_id.id
-                else:
+                elif line.salary_rule_id.debit_employee_account == 'other':
                     debit_account_id = line.salary_rule_id.account_debit.id
+                else:
+                    debit_account_id = False
                 # choose the account to create the credit move
                 if (line.salary_rule_id.credit_employee_account == 'payable'
                         and slip.employee_id.address_home_id
@@ -137,8 +139,10 @@ class hr_payslip(osv.osv):
                         and slip.employee_id.address_home_id
                         and slip.employee_id.address_home_id.property_account_receivable):
                     credit_account_id = slip.employee_id.address_home_id.property_account_receivable.id
-                else:
+                elif line.salary_rule_id.credit_employee_account == 'other':
                     credit_account_id = line.salary_rule_id.account_credit.id
+                else:
+                    credit_account_id = False
 
                 if debit_account_id:
                     debit_line = (0, 0, {

--- a/addons/hr_payroll_account/hr_payroll_account.py
+++ b/addons/hr_payroll_account/hr_payroll_account.py
@@ -101,7 +101,6 @@ class hr_payslip(osv.osv):
             else:
                 period_id = slip.period_id.id
 
-            default_partner_id = slip.employee_id.address_home_id.id
             name = _('Payslip of %s') % (slip.employee_id.name)
             move = {
                 'narration': name,
@@ -114,16 +113,18 @@ class hr_payslip(osv.osv):
                 amt = slip.credit_note and -line.total or line.total
                 if float_is_zero(amt, precision_digits=precision):
                     continue
-                partner_id = line.salary_rule_id.register_id.partner_id and line.salary_rule_id.register_id.partner_id.id or default_partner_id
+                partner_id = False
                 # choose the account to create the debit move
                 if (line.salary_rule_id.debit_employee_account == 'receivable'
                         and slip.employee_id.address_home_id
                         and slip.employee_id.address_home_id.property_account_receivable):
                     debit_account_id = slip.employee_id.address_home_id.property_account_receivable.id
+                    partner_id = slip.employee_id.address_home_id.id
                 elif (line.salary_rule_id.debit_employee_account == 'payable'
                         and slip.employee_id.address_home_id
                         and slip.employee_id.address_home_id.property_account_payable):
                     debit_account_id = slip.employee_id.address_home_id.property_account_payable.id
+                    partner_id = slip.employee_id.address_home_id.id
                 else:
                     debit_account_id = line.salary_rule_id.account_debit.id
                 # choose the account to create the credit move
@@ -131,6 +132,7 @@ class hr_payslip(osv.osv):
                         and slip.employee_id.address_home_id
                         and slip.employee_id.address_home_id.property_account_payable):
                     credit_account_id = slip.employee_id.address_home_id.property_account_payable.id
+                    partner_id = slip.employee_id.address_home_id.id
                 elif (line.salary_rule_id.credit_employee_account == 'receivable'
                         and slip.employee_id.address_home_id
                         and slip.employee_id.address_home_id.property_account_receivable):
@@ -142,7 +144,7 @@ class hr_payslip(osv.osv):
                     debit_line = (0, 0, {
                     'name': line.name,
                     'date': timenow,
-                    'partner_id': (line.salary_rule_id.register_id.partner_id or line.salary_rule_id.account_debit.type in ('receivable', 'payable')) and partner_id or False,
+                    'partner_id': partner_id,
                     'account_id': debit_account_id,
                     'journal_id': slip.journal_id.id,
                     'period_id': period_id,
@@ -159,7 +161,7 @@ class hr_payslip(osv.osv):
                     credit_line = (0, 0, {
                     'name': line.name,
                     'date': timenow,
-                    'partner_id': (line.salary_rule_id.register_id.partner_id or line.salary_rule_id.account_credit.type in ('receivable', 'payable')) and partner_id or False,
+                    'partner_id': partner_id,
                     'account_id': credit_account_id,
                     'journal_id': slip.journal_id.id,
                     'period_id': period_id,

--- a/addons/hr_payroll_account/hr_payroll_account_view.xml
+++ b/addons/hr_payroll_account/hr_payroll_account_view.xml
@@ -26,9 +26,13 @@
                     <page string="Accounting">
                         <group colspan="4">
                             <field name="debit_employee_account" />
-                            <field name="account_debit" string="..." attrs="{'invisible': [('debit_employee_account','!=','other')]}"/>
+                            <field name="account_debit" string="..."
+                                   attrs="{'invisible': [('debit_employee_account','!=','other')],
+                                           'required': [('debit_employee_account','=','other')]}"/>
                             <field name="credit_employee_account"/>
-                            <field name="account_credit" string="..." attrs="{'invisible': [('credit_employee_account','!=','other')]}"/>
+                            <field name="account_credit" string="..."
+                                   attrs="{'invisible': [('credit_employee_account','!=','other')],
+                                           'required': [('credit_employee_account','=','other')]}"/>
                             <field name="analytic_account_id" groups="analytic.group_analytic_accounting"/>
                             <field name="account_tax_id"/>
                         </group>

--- a/addons/hr_payroll_account/hr_payroll_account_view.xml
+++ b/addons/hr_payroll_account/hr_payroll_account_view.xml
@@ -25,8 +25,10 @@
               <xpath expr="/form/notebook/page[@string='Child Rules']" position="after">
                     <page string="Accounting">
                         <group colspan="4">
-                            <field name="account_debit" />
-                            <field name="account_credit"/>
+                            <field name="debit_employee_account" />
+                            <field name="account_debit" string="..." attrs="{'invisible': [('debit_employee_account','!=','other')]}"/>
+                            <field name="credit_employee_account"/>
+                            <field name="account_credit" string="..." attrs="{'invisible': [('credit_employee_account','!=','other')]}"/>
                             <field name="analytic_account_id" groups="analytic.group_analytic_accounting"/>
                             <field name="account_tax_id"/>
                         </group>

--- a/addons/hr_payroll_account/test/hr_payroll_account.yml
+++ b/addons/hr_payroll_account/test/hr_payroll_account.yml
@@ -63,6 +63,9 @@
           {'credit_employee_account': 'payable',
            'debit_employee_account': 'other',
            'account_debit': ref('account.a_salary_expense')})
+      # 'other' with false is equivalent to no selection: it does nothing
+      self.write(cr, uid, ref('hr_payroll.hr_rule_taxable'),
+          {'credit_employee_account': 'other', 'account_credit': False})
 -
   I create a contract for "John".
 -
@@ -144,6 +147,7 @@
     payslip = self.browse(cr, uid, ref("hr_payslip_0"))
     assert payslip.move_id, "Accounting Entries has not been created"
     line_accounts = [l.account_id.name for l in payslip.move_id.line_id]
+    assert len(line_accounts) == 2, "Wrong number of accounting entries created"
     assert 'John account' in line_accounts, "Wrong accounting entries created"
 -
   I verify that the payslip is in done state.

--- a/addons/hr_payroll_account/test/hr_payroll_account.yml
+++ b/addons/hr_payroll_account/test/hr_payroll_account.yml
@@ -24,6 +24,22 @@
     bank_account_id: res_partner_bank_0
     vehicle_distance: 0.0
 -
+  I create an account for John
+-
+  !record {model: account.account, id: john_account}:
+    code: 'X1111JOHN'
+    company_id: base.main_company
+    currency_mode: current
+    name: John account
+    type: payable
+    user_type: account.data_account_type_payable
+    parent_id: account.cli
+-
+  I assign this account on the home address
+-
+  !record {model: res.partner, id: base.res_partner_address_2}:
+    property_account_payable: john_account
+-
   I create a salary structure for 'Software Developer'.
 -
   !record {model: hr.payroll.structure, id: hr_payroll_structure_softwaredeveloper}:
@@ -38,6 +54,15 @@
       - hr_payroll.hr_salary_rule_providentfund1
       - hr_payroll.hr_salary_rule_meal_voucher
       - hr_payroll.hr_salary_rule_sales_commission
+-
+  I set the employee account on the Net salary rule
+-
+    !python {model: hr.salary.rule}: |
+      rule_id = ref('hr_payroll.hr_rule_net')
+      self.write(cr, uid, ref('hr_payroll.hr_rule_net'),
+          {'credit_employee_account': 'payable',
+           'debit_employee_account': 'other',
+           'account_debit': ref('account.a_salary_expense')})
 -
   I create a contract for "John".
 -
@@ -118,6 +143,8 @@
   !python {model: hr.payslip}: |
     payslip = self.browse(cr, uid, ref("hr_payslip_0"))
     assert payslip.move_id, "Accounting Entries has not been created"
+    line_accounts = [l.account_id.name for l in payslip.move_id.line_id]
+    assert 'John account' in line_accounts, "Wrong accounting entries created"
 -
   I verify that the payslip is in done state.
 -


### PR DESCRIPTION
This is a proposal for issue #4491.

In the accounting tab of the salary rules, for both debit and credit accounts, it allows to select either "employee payable account", "employee receivable account", or "Select an account below".
If the choice is set to the employee payable or receivable account, then the employee's account is used during the creation of the accounting move.
If the choice is set to "Select an account below", the standard field is unhidden and one can choose an account like it is currently.

This change is supposed to be backward compatible, but there is no way to be sure because there are no tests for the accounting part of this module. I've enhanced the YML test to create an employee account, use it in the Net rule and check that there is a move line using this account in the resulting move.