### PR TITLE
Allow to display and change the link between sale orders and their invoi...

### DIFF
--- a/addons/purchase/purchase_view.xml
+++ b/addons/purchase/purchase_view.xml
@@ -249,6 +249,9 @@
                                 </group>
                             </group>
                         </page>
+                        <page string="Invoices">
+                            <field name="invoice_ids"/>
+                        </page>
                     </notebook>
                 </sheet>
                 <div class="oe_chatter">

--- a/addons/sale/sale.py
+++ b/addons/sale/sale.py
@@ -220,7 +220,7 @@ class sale_order(osv.osv):
         'project_id': fields.many2one('account.analytic.account', 'Contract / Analytic', readonly=True, states={'draft': [('readonly', False)], 'sent': [('readonly', False)]}, help="The analytic account related to a sales order."),
 
         'order_line': fields.one2many('sale.order.line', 'order_id', 'Order Lines', readonly=True, states={'draft': [('readonly', False)], 'sent': [('readonly', False)]}),
-        'invoice_ids': fields.many2many('account.invoice', 'sale_order_invoice_rel', 'order_id', 'invoice_id', 'Invoices', readonly=True, help="This is the list of invoices that have been generated for this sales order. The same sales order may have been invoiced in several times (by line for example)."),
+        'invoice_ids': fields.many2many('account.invoice', 'sale_order_invoice_rel', 'order_id', 'invoice_id', 'Invoices', help="This is the list of invoices that have been generated for this sales order. The same sales order may have been invoiced in several times (by line for example)."),
         'invoiced_rate': fields.function(_invoiced_rate, string='Invoiced Ratio', type='float'),
         'invoiced': fields.function(_invoiced, string='Paid',
             fnct_search=_invoiced_search, type='boolean', help="It indicates that an invoice has been paid."),

--- a/addons/sale/sale_view.xml
+++ b/addons/sale/sale_view.xml
@@ -269,6 +269,9 @@
                                 </group>
                             </group>
                         </page>
+                        <page string="Invoices">
+                            <field name="invoice_ids"/>
+                        </page>
                     </notebook>
                 </sheet>
                 <div class="oe_chatter">


### PR DESCRIPTION
There is a hidden link between sale order and invoices : a invoice_ids field.
We sometime need to modify this link, in case we create an invoice from a sale order, and the final draft invoice is modified to link to another partner.

This PR just add a tab in the sale.order view to display the corresponding invoices.
The field itself is set to readonly=False to be able to modify it (and correct the link between the sale order and the modified invoice).
The same tab is added to the purchase order (but the invoice_ids of the purchase order was already readonly=False).