### PR TITLE
Search view disable custom filters, fix issue #3258

### DIFF
--- a/addons/web/static/src/js/view_form.js
+++ b/addons/web/static/src/js/view_form.js
@@ -4815,25 +4815,29 @@ instance.web.form.SelectCreatePopup = instance.web.form.AbstractFormPopup.extend
                 contexts: [this.context]
             }).done(function (results) {
                 var search_defaults = {};
+                var options = {};
                 _.each(results.context, function (value_, key) {
                     var match = /^search_default_(.*)$/.exec(key);
                     if (match) {
                         search_defaults[match[1]] = value_;
                     }
+                    if (key === 'search_disable_custom_filters'){
+                        options['disable_custom_filters'] = value_;
+                    }
                 });
-                self.setup_search_view(search_defaults);
+                self.setup_search_view(search_defaults, options);
             });
         } else { // "form"
             this.new_object();
         }
     },
-    setup_search_view: function(search_defaults) {
+    setup_search_view: function(search_defaults, options) {
         var self = this;
         if (this.searchview) {
             this.searchview.destroy();
         }
         this.searchview = new instance.web.SearchView(this,
-                this.dataset, false,  search_defaults);
+                this.dataset, false,  search_defaults, options);
         this.searchview.on('search_data', self, function(domains, contexts, groupbys) {
             if (self.initial_ids) {
                 self.do_search(domains.concat([[["id", "in", self.initial_ids]], self.domain]),


### PR DESCRIPTION
This aims to fix issue #3258.

This was refused by odoo 2014-11-24 12:03 GMT+01:00 Somesh Khare (skh) <skh@mail.odoo.com>:
"I have checked your pull request and I saw that you have been added a new attribute as "search_disable_custom_filters" to disable the custom filter, As it could be consider as a new functionality or behaviour, here we could not consider such feature request for stable series to avoid regression on the database those are already into production. However you can create a new pull request for trunk version and If our R & D team will find it suitable to introduce into the future version they will merge it. But for stable series we could not consider this. Hope you understand this." 

And approved but still not merged on OCB: https://github.com/OCA/OCB/pull/81