### PR TITLE
Stop hammering ir_translation id sequence

### DIFF
--- a/openerp/addons/base/ir/ir_translation.py
+++ b/openerp/addons/base/ir/ir_translation.py
@@ -69,7 +69,13 @@ class ir_translation_import_cursor(object):
 
         # Note that Postgres will NOT inherit the constraints or indexes
         # of ir_translation, so this copy will be much faster.
+        # Thanks to the explicit default value for 'id' overriding,
+        # it will not bump the sequence either
+        # (id is actually unsused in the temp table).
+        # This will be faster, and avoid the possibility to hit the limit
+        # at 2**31 in months (fatal startup error)
         cr.execute('''CREATE TEMP TABLE %s(
+            id INT DEFAULT 0,
             imd_model VARCHAR(64),
             imd_name VARCHAR(128)
             ) INHERITS (%s) ''' % (self._table_name, self._parent_table))


### PR DESCRIPTION
Description of the issue/feature this PR addresses: startup failures due to ir_translation_id_seq overflow (DataError)

Current behavior before PR: ir_translation_id_seq grows by big steps, can reach 2**31 in months

Desired behavior after PR is merged: ir_translation_id_seq grows only if new translations appear

(I have **NOT** signed Odoo CLA)

We've had some instances actually reaching the 2**31 limit, because
the temporary table used to prepare potential insertions used the same
id sequence as the main table, hence each insert in the temporary table
bumps the sequence.

Aggravations:

- if one hits the wall, the instance won't start
- if one resets the sequence too close from an existing id, it won't start either
- the existing ids are spread across the whole spectrum, making it hard to find
  a safe range to reset the sequence.

Yes this probably means instances that restart too much, but that's another issue.

The whole system is questionable at best [1] but this fix should have no impact, and
improve a bit startup performance and PostgreSQL health. On the other hand, we can't
guarantee without a long analysis that's out of our scope that even changing
ir_translation to a bigint would have no impact, yet alone give this the full rewrite
it certainly deserves.

[1] for starters, why use the DB at all in preparation, and use a temporary table
    that's logically tied to a specific connection ?