### PR TITLE
Allow to render report 'offline'

### DIFF
--- a/addons/report/models/report.py
+++ b/addons/report/models/report.py
@@ -225,7 +225,6 @@ class Report(osv.Model):
             for node in root.xpath("//html/head/style"):
                 css += node.text
 
-            cssfiles = []
             for xmlelt in [
                 lxml.html.fromstring(
                     render_minimal(dict(css='', subst=True, body='', base_url=''))
@@ -233,11 +232,10 @@ class Report(osv.Model):
                 root,
             ]:
                 for node in xmlelt.xpath("//link[@rel='stylesheet']"):
-                    css_path = node.get('href')[1:]
-                    if css_path not in cssfiles:
-                        cssfile = file_open(css_path)
-                        css += cssfile.read()
-                        cssfiles.append(css_path)
+                    css_path = node.get('href')
+                    if css_path.startswith("/"):
+                        css_path = css_path[1:]
+                    css += file_open(css_path).read()
                     node.getparent().remove(node)
 
             for node in root.xpath(match_klass.format('header')):


### PR DESCRIPTION
In case (unit test in my consideration) wkhtmltopdf is not able to access to
a running server, this PR allow to render pdf as expected (as if it was done
through the UI) by loding css files directly from file system.

Could be a way to restrict wkhtml to access to internet
